### PR TITLE
fix: add export parse-error

### DIFF
--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -8,3 +8,4 @@ export * from './lib/interfaces/parse-meta';
 export * from './lib/interfaces/papa-parse-parser';
 export * from './lib/interfaces/parse-result';
 export * from './lib/interfaces/unparse-config';
+export * from './lib/interfaces/parse-error';


### PR DESCRIPTION
Fix to export ParseError is missing