### PR TITLE
Update parse-config.ts

### DIFF
--- a/src/lib/interfaces/parse-config.ts
+++ b/src/lib/interfaces/parse-config.ts
@@ -102,7 +102,7 @@ export interface ParseConfig {
      * If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to 'greedy',
      * lines that don't have any content (those which have only whitespace after parsing) will also be skipped.
      */
-    skipEmptyLines?: boolean | string;
+    skipEmptyLines?: boolean | 'greedy';
 
     /**
      * A callback function, identical to step, which activates streaming.

--- a/src/lib/interfaces/parse-config.ts
+++ b/src/lib/interfaces/parse-config.ts
@@ -102,7 +102,7 @@ export interface ParseConfig {
      * If true, lines that are completely empty (those which evaluate to an empty string) will be skipped. If set to 'greedy',
      * lines that don't have any content (those which have only whitespace after parsing) will also be skipped.
      */
-    skipEmptyLines?: boolean;
+    skipEmptyLines?: boolean | string;
 
     /**
      * A callback function, identical to step, which activates streaming.


### PR DESCRIPTION
Papaparse supports skipEmptyLines as string for 'greedy'.

Is possible to apply this also on v3?