### PR TITLE
Typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+*.tgz
 
 # dependencies
 /node_modules

--- a/src/lib/interfaces/unparse-data.ts
+++ b/src/lib/interfaces/unparse-data.ts
@@ -1,0 +1,11 @@
+
+export type ArrayData = Array<Array<string|number>>;
+
+export type ArrayObject = Array<{ [k: string]: string|number }>;
+
+export interface MapObject {
+    fields: Array<string>;
+    data: Array<Array<string|number>>;
+}
+
+export type UnparseData = ArrayData | ArrayObject | MapObject;

--- a/src/lib/interfaces/unparse-data.ts
+++ b/src/lib/interfaces/unparse-data.ts
@@ -1,4 +1,3 @@
-
 export type ArrayData = Array<Array<string|number>>;
 
 export type ArrayObject = Array<{ [k: string]: string|number }>;

--- a/src/lib/papa.spec.ts
+++ b/src/lib/papa.spec.ts
@@ -35,6 +35,25 @@ describe('Papa', () => {
         }));
     }));
 
+    it('should parse basic CSV from string and return each step', inject([Papa], (papa: Papa) => {
+        const csv = '"a","b,","c"""\nd,e,f\ng,h,i';
+
+        const expected = [
+            ['a', 'b,', 'c"'],
+            ['d', 'e', 'f'],
+            ['g', 'h', 'i']
+        ];
+
+        let line = 0;
+        papa.parse(csv, {
+            step: result => {
+                // Check step data
+                expect(result.data).toEqual(jasmine.objectContaining(expected[line]));
+                line++;
+            }
+        });
+    }));
+
     it('should parse CSV from local file', inject([Papa], (papa: Papa) => {
         const csv = '"a","b,","c"""\nd,e,f\ng,h,i';
         const universalBOM = '\uFEFF';

--- a/src/lib/papa.spec.ts
+++ b/src/lib/papa.spec.ts
@@ -114,6 +114,7 @@ describe('Papa', () => {
         });
 
         expect(result).toBe(`=a,+b,-c,@d,"'1e","'2f","'3g","'4h"`);
+    }));
 
     it('should generate CSV from array Object', inject([Papa], (papa: Papa) => {
         const data = [

--- a/src/lib/papa.spec.ts
+++ b/src/lib/papa.spec.ts
@@ -114,6 +114,35 @@ describe('Papa', () => {
         });
 
         expect(result).toBe(`=a,+b,-c,@d,"'1e","'2f","'3g","'4h"`);
+
+    it('should generate CSV from array Object', inject([Papa], (papa: Papa) => {
+        const data = [
+            { A: 'a', B: 'b,', C: 'c"' },
+            { A: 'd', B: 'e', C: 'f' },
+            { A: 'g', B: 'h', C: 'i' },
+        ];
+        const result = papa.unparse(data, {
+            delimiter: ','
+        });
+
+        expect(result).toBe('A,B,C\r\na,"b,","c"""\r\nd,e,f\r\ng,h,i');
+    }));
+
+    it('should generate CSV from Map Object', inject([Papa], (papa: Papa) => {
+        const data = {
+            fields: ['A', 'B', 'C'],
+            data: [
+                ['a', 'b,', 'c"'],
+                ['d', 'e', 'f'],
+                ['g', 'h', 'i']
+            ]
+        };
+
+        const result = papa.unparse(data, {
+            delimiter: ','
+        });
+
+        expect(result).toBe('A,B,C\r\na,"b,","c"""\r\nd,e,f\r\ng,h,i');
     }));
 
     // Test setters

--- a/src/lib/papa.ts
+++ b/src/lib/papa.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { ParseResult } from './interfaces/parse-result';
 import { ParseConfig } from './interfaces/parse-config';
 import { UnparseConfig } from './interfaces/unparse-config';
+import { UnparseData } from './interfaces/unparse-data';
 import * as lib from 'papaparse/papaparse.min.js';
 
 @Injectable({
@@ -20,7 +21,7 @@ export class Papa {
     /**
      * Convert an array into CSV
      */
-    public unparse(data, config?: UnparseConfig): string {
+    public unparse(data: UnparseData, config?: UnparseConfig): string {
         return this._papa.unparse(data, config);
     }
 


### PR DESCRIPTION
- Add typing for valid Unparse Data
- Change `parse()` to accept `Blob` as Papa can handle it and `File extends Blob` so `File` still valid
