### PR TITLE
Make papaparse a dependency

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -7,5 +7,8 @@
   "lib": {
     "entryFile": "src/public_api.ts"
   },
-  "deleteDestPath": true
+  "deleteDestPath": true,
+  "allowedNonPeerDependencies": [
+    "papaparse"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -43,9 +43,7 @@
     "e2e": "ng e2e"
   },
   "dependencies": {
-    "tslib": "^2.0.0"
-  },
-  "peerDependencies": {
+    "tslib": "^2.0.0",
     "papaparse": "^5.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Some version of NPM and Yarn doesn't automatically install peerDependencies.
This PR changes papaparse back to a traditional dependency.

Closes #102 